### PR TITLE
Swift 2.2 : remove deprecated methods

### DIFF
--- a/Source/CubicBezier.swift
+++ b/Source/CubicBezier.swift
@@ -59,8 +59,8 @@ private func CubicBezierBinarySubdivide(x: CGFloat, x1: CGFloat, x2: CGFloat) ->
         } else {
             start = currentT
         }
-        
-    } while (fabs(currentX) > epsilon && ++i < maxIterations)
+        i += 1
+    } while (fabs(currentX) > epsilon && i < maxIterations)
     
     return currentT
 }

--- a/Source/Interpolatable.swift
+++ b/Source/Interpolatable.swift
@@ -12,7 +12,7 @@ import UIKit
 Protocol for types that can return smoothly incremented values between two given values.
 */
 public protocol Interpolatable {
-    typealias ValueType
+    associatedtype ValueType
     /**
     Find a value at a certain progress point (from 0 to 1) between two values of the same type.
     

--- a/Source/LayerStrokeEndAnimation.swift
+++ b/Source/LayerStrokeEndAnimation.swift
@@ -24,7 +24,7 @@ public class LayerStrokeEndAnimation : Animation<CGFloat>, Animatable {
         // CAAnimations are lost when application enters the background, so re-add them
         NSNotificationCenter.defaultCenter().addObserver(
             self,
-            selector: "createStrokeEndAnimation",
+            selector: #selector(LayerStrokeEndAnimation.createStrokeEndAnimation),
             name: UIApplicationDidBecomeActiveNotification,
             object: nil)
     }

--- a/Source/LayerStrokeStartAnimation.swift
+++ b/Source/LayerStrokeStartAnimation.swift
@@ -23,7 +23,7 @@ public class LayerStrokeStartAnimation : Animation<CGFloat>, Animatable {
         // CAAnimations are lost when application enters the background, so re-add them
         NSNotificationCenter.defaultCenter().addObserver(
             self,
-            selector: "createStrokeStartAnimation",
+            selector: #selector(LayerStrokeStartAnimation.createStrokeStartAnimation),
             name: UIApplicationDidBecomeActiveNotification,
             object: nil)
     }

--- a/Source/PathPositionAnimation.swift
+++ b/Source/PathPositionAnimation.swift
@@ -34,7 +34,7 @@ public class PathPositionAnimation : Animation<CGFloat>, Animatable {
         // CAAnimations are lost when application enters the background, so re-add them
         NSNotificationCenter.defaultCenter().addObserver(
             self,
-            selector: "createKeyframeAnimation",
+            selector: #selector(PathPositionAnimation.createKeyframeAnimation),
             name: UIApplicationDidBecomeActiveNotification,
             object: nil)
     }


### PR DESCRIPTION
I removed warnings concerning deprecated methods in Swift 2.2, definitively removed on Swift 3.0
