### PR TITLE
Add ability to replace a filmstrip keyframe

### DIFF
--- a/Example/RazzleDazzleTests/RAZFilmstripSpec.swift
+++ b/Example/RazzleDazzleTests/RAZFilmstripSpec.swift
@@ -105,6 +105,14 @@ class FilmstripSpec: QuickSpec {
                 floatFilmstrip.setValue(30, atTime: 3)
                 expect(floatFilmstrip.valueAtTime(2.5)).to(equal(25))
             }
+            it("should allow replacement of keyframes") {
+                floatFilmstrip[2] = 0
+                floatFilmstrip[4] = 5
+                floatFilmstrip[2] = 3
+                expect(floatFilmstrip[1]).to(equal(3))
+                expect(floatFilmstrip[2]).to(equal(3))
+                expect(floatFilmstrip[3]).to(equal(4))
+            }
         }
     }
 }

--- a/Source/Filmstrip.swift
+++ b/Source/Filmstrip.swift
@@ -13,10 +13,6 @@ private class Keyframe<T: Interpolatable where T.ValueType == T> {
     let value : T
     let easing : EasingFunction
     
-    private convenience init(time: CGFloat, value: T) {
-        self.init(time: time, value: value, easing: EasingFunctionLinear)
-    }
-    
     private init(time: CGFloat, value: T, easing: EasingFunction) {
         self.time = time
         self.value = value
@@ -48,14 +44,14 @@ public class Filmstrip<T: Interpolatable where T.ValueType == T> {
         }
     }
     
-    public func setValue(value: T, atTime time: CGFloat) {
+    public func setValue(value: T, atTime time: CGFloat, easing: EasingFunction = EasingFunctionLinear) {
         let index = indexOfKeyframeAfterTime(time) ?? keyframes.count
-        keyframes.insert(Keyframe(time: time, value: value), atIndex: index)
-    }
-    
-    public func setValue(value: T, atTime time: CGFloat, easing: EasingFunction) {
-        let index = indexOfKeyframeAfterTime(time) ?? keyframes.count
-        keyframes.insert(Keyframe(time: time, value: value, easing: easing), atIndex: index)
+        if index > 0 && keyframes[index-1].time == time {
+            keyframes.replaceRange(index-1..<index, with: [Keyframe(time: time, value: value, easing: easing)])
+        }
+        else {
+            keyframes.insert(Keyframe(time: time, value: value, easing: easing), atIndex: index)
+        }
     }
     
     public func valueAtTime(time: CGFloat) -> T {


### PR DESCRIPTION
This commit addresses an issue that occurs if you try to set a Filmstrip's value for a time that already has a keyframe. It also cleans up a bit of redundant code by using default values.

I encountered the issue with a `ScaleAnimation` that needed to change keyframe values based on the orientation of view controller.
