### PR TITLE
Use "guard" instead of "if"

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Then, all you need to do is to make the appropriate changes to your view when th
 
 ```swift
 public func animate(time: CGFloat) {
-	if !hasKeyframes() {return}
+	guard hasKeyframes() else { return }
 	view.layer.borderWidth = self[time]
 }
 ```


### PR DESCRIPTION
Since the `hasKeyframes()` condition is being used as a guard in this case, and when it fails the function returns early, `guard` is more stylistically appropriate than `if`.
