### PR TITLE
Support resetting the animation for reuse

### DIFF
--- a/Source/Animation.swift
+++ b/Source/Animation.swift
@@ -36,6 +36,10 @@ open class Animation<T: Interpolatable> where T.ValueType == T {
         return !filmstrip.isEmpty
     }
 
+    open func removeAllKeyframes() {
+        filmstrip.removeAll()
+    }
+
     open func validateValue(_ value: T) -> Bool {
         return true
     }

--- a/Source/Filmstrip.swift
+++ b/Source/Filmstrip.swift
@@ -75,6 +75,10 @@ public class Filmstrip<T: Interpolatable> where T.ValueType == T {
         }
         return value
     }
+
+    public func removeAll() {
+        keyframes.removeAll()
+    }
     
     private func indexOfKeyframeAfterTime(_ time: CGFloat) -> Int? {
         var indexAfter : Int?


### PR DESCRIPTION
I am using RazzleDazzle to animate items in a collection view. The problem I came across is that the cell views are reused and animations configured before need to be cleared. I added `#removeAllKeyframes` so that I can reuse the same animation object attached to the cell.

The code while preparing cell for collection view:
```swift
func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath) as! Cell
        var animation: ScaleAnimation // ScaleAnimation as example
        if cell.animation == nil {
            animation = ScaleAnimation(view: cell)
            animator.addAnimation(animation)
            cell.animation = animation
        } else {
            animation = cell.animation!
        }

        animation.removeAllKeyframes()
        // Set up the animation here

        return cell
}
```