### PR TITLE
remove code coverage from production scheme due to LLVM

### DIFF
--- a/Example/RazzleDazzle.xcodeproj/xcshareddata/xcschemes/RazzleDazzle.xcscheme
+++ b/Example/RazzleDazzle.xcodeproj/xcshareddata/xcschemes/RazzleDazzle.xcscheme
@@ -40,8 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -70,6 +70,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Appstore not requires that in production build code coverage should be **disabled**. Further discussion on apple developer forum:

https://forums.developer.apple.com/thread/81893

When you integrate RazzleDazzle with carthage it will return error:

> Invalid Bundle - Disallowed LLVM instrumentation. Do not submit apps with LLVM profiling instrumentation or coverage collection enabled. Turn off LLVM profiling or code coverage, rebuild your app and resubmit the app.  

After release to the store. Disabling code coverage in scheme setting fix this issue.
